### PR TITLE
Add docs for  new .NET 8 with new render modes, SDK parameters compon…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,8 +51,9 @@ jobs:
       working-directory: src/Cropper.Blazor/Cropper.Blazor.UnitTests    
       
     - name: Coverage
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.net6.0.cobertura.xml, coverage.net7.0.cobertura.xml, coverage.net8.0.cobertura.xml
         fail_ci_if_error: true
         verbose: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,8 +51,7 @@ jobs:
       working-directory: src/Cropper.Blazor/Cropper.Blazor.UnitTests    
       
     - name: Coverage
-      - uses: actions/checkout@main
-      - uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.net6.0.cobertura.xml, coverage.net7.0.cobertura.xml, coverage.net8.0.cobertura.xml

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,8 @@ jobs:
       working-directory: src/Cropper.Blazor/Cropper.Blazor.UnitTests    
       
     - name: Coverage
-      uses: codecov/codecov-action@v4
+      - uses: actions/checkout@main
+      - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.net6.0.cobertura.xml, coverage.net7.0.cobertura.xml, coverage.net8.0.cobertura.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,8 @@ jobs:
       working-directory: src/Cropper.Blazor/Cropper.Blazor.UnitTests    
     
     - name: Coverage
-      uses: codecov/codecov-action@v4
+      - uses: actions/checkout@main
+      - uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.net6.0.cobertura.xml, coverage.net7.0.cobertura.xml, coverage.net8.0.cobertura.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,7 @@ jobs:
       working-directory: src/Cropper.Blazor/Cropper.Blazor.UnitTests    
     
     - name: Coverage
-      - uses: actions/checkout@main
-      - uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.net6.0.cobertura.xml, coverage.net7.0.cobertura.xml, coverage.net8.0.cobertura.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,9 @@ jobs:
       working-directory: src/Cropper.Blazor/Cropper.Blazor.UnitTests    
     
     - name: Coverage
-      uses: codecov/codecov-action@v3.1.4
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.net6.0.cobertura.xml, coverage.net7.0.cobertura.xml, coverage.net8.0.cobertura.xml
         fail_ci_if_error: true
         verbose: true

--- a/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicInputReplaceImageWithNewSizeExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicInputReplaceImageWithNewSizeExample.razor
@@ -80,6 +80,13 @@
                 IsAvailableInitCropper = false;
             }
 
+            // In the new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
+            // We strongly recommend using StateHasChanged() method after changing a component's parameter,
+            // but be careful with this because you're updating the entire component where there may be more than one component,
+            // which can also affect performance a bit when there are too many components on the page or animations.
+            // As an option, make a separate wrapper with minimal functionality in this case.
+            //StateHasChanged();
+
             await Task.WhenAll(
                 CropperComponent!.ReplaceAsync(newSrc, false).AsTask()
                 // For certain platforms based on WebView in MAUI, Windows Forms and WPF Blazor Hybrids, the 'RevokeObjectUrlAsync(OldSrc)' method does not work correctly in this place.

--- a/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicInputReplaceImageWithNewSizeExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicInputReplaceImageWithNewSizeExample.razor
@@ -80,7 +80,7 @@
                 IsAvailableInitCropper = false;
             }
 
-            // In the new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
+            // In the .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
             // We strongly recommend using StateHasChanged() method after changing a component's parameter,
             // but be careful with this because you're updating the entire component where there may be more than one component,
             // which can also affect performance a bit when there are too many components on the page or animations.

--- a/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicInputReplaceImageWithSameSizeExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicInputReplaceImageWithSameSizeExample.razor
@@ -80,6 +80,13 @@
                 IsAvailableInitCropper = false;
             }
 
+            // In the new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
+            // We strongly recommend using StateHasChanged() method after changing a component's parameter,
+            // but be careful with this because you're updating the entire component where there may be more than one component,
+            // which can also affect performance a bit when there are too many components on the page or animations.
+            // As an option, make a separate wrapper with minimal functionality in this case.
+            //StateHasChanged();
+
             await Task.WhenAll(
                 CropperComponent!.ReplaceAsync(newSrc, true).AsTask()
                 // For certain platforms based on WebView in MAUI, Windows Forms and WPF Blazor Hybrids, the 'RevokeObjectUrlAsync(OldSrc)' method does not work correctly in this place.

--- a/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicInputReplaceImageWithSameSizeExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicInputReplaceImageWithSameSizeExample.razor
@@ -80,7 +80,7 @@
                 IsAvailableInitCropper = false;
             }
 
-            // In the new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
+            // In the .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
             // We strongly recommend using StateHasChanged() method after changing a component's parameter,
             // but be careful with this because you're updating the entire component where there may be more than one component,
             // which can also affect performance a bit when there are too many components on the page or animations.

--- a/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicReplaceImageWithNewSizeExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicReplaceImageWithNewSizeExample.razor
@@ -50,6 +50,13 @@
     {
         IsReplaced = true;
 
+        // In the new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
+        // We strongly recommend using StateHasChanged() method after changing a component's parameter,
+        // but be careful with this because you're updating the entire component where there may be more than one component,
+        // which can also affect performance a bit when there are too many components on the page or animations.
+        // As an option, make a separate wrapper with minimal functionality in this case.
+        //StateHasChanged();
+
         await CropperComponent!.ReplaceAsync("images/raspberry.jpg", false);
 
         // Releases an existing object URL which was previously created by calling URL.

--- a/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicReplaceImageWithNewSizeExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicReplaceImageWithNewSizeExample.razor
@@ -50,7 +50,7 @@
     {
         IsReplaced = true;
 
-        // In the new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
+        // In the .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
         // We strongly recommend using StateHasChanged() method after changing a component's parameter,
         // but be careful with this because you're updating the entire component where there may be more than one component,
         // which can also affect performance a bit when there are too many components on the page or animations.

--- a/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicReplaceImageWithSameSizeExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicReplaceImageWithSameSizeExample.razor
@@ -50,7 +50,7 @@
     {
         IsReplaced = true;
 
-        // In the new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
+        // In the .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
         // We strongly recommend using StateHasChanged() method after changing a component's parameter,
         // but be careful with this because you're updating the entire component where there may be more than one component,
         // which can also affect performance a bit when there are too many components on the page or animations.

--- a/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicReplaceImageWithSameSizeExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Replace/Examples/BasicReplaceImageWithSameSizeExample.razor
@@ -50,6 +50,13 @@
     {
         IsReplaced = true;
 
+        // In the new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
+        // We strongly recommend using StateHasChanged() method after changing a component's parameter,
+        // but be careful with this because you're updating the entire component where there may be more than one component,
+        // which can also affect performance a bit when there are too many components on the page or animations.
+        // As an option, make a separate wrapper with minimal functionality in this case.
+        //StateHasChanged();
+
         await CropperComponent!.ReplaceAsync("images/raspberry.jpg", true);
 
         // Releases an existing object URL which was previously created by calling URL.


### PR DESCRIPTION
## Target
<!--
  Why are you making this change?
 -->
https://github.com/CropperBlazor/Cropper.Blazor/issues/332
Add docs for  new .NET 8 with new render modes, SDK parameters components are not updated timely when using 'blazor.web.js'.
#### Open Questions
<!-- OPTIONAL
  - [ ] Use the GitHub checklists to spark discussion on issues that may arise from your approach. Please tick the box and explain your answer.
-->

## Checklist
<!--
  It serves as a gentle reminder for common tasks. Confirm it's done and check everything that applies.
-->
- [x] Documentation updated
- [ ] Tests cover new or modified code
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New dependencies added
- [ ] Includes breaking changes
- [ ] Version bumped

## Visuals
<!-- OPTIONAL
  Show results both before and after this change. When the output changes, it can be a screenshot of a trace, metric, or log illustrating the change.
-->
