### PR TITLE
Update InstallationManualCssFontsExample.razor

### DIFF
--- a/src/Cropper.Blazor/Client/Pages/Home/Installation/Examples/InstallationManualCssFontsExample.razor
+++ b/src/Cropper.Blazor/Client/Pages/Home/Installation/Examples/InstallationManualCssFontsExample.razor
@@ -1,3 +1,3 @@
 ﻿@namespace Cropper.Blazor.Client.Pages.Examples
 
-<link href="_content /Cropper.Blazor/cropper.min.css" rel="stylesheet" />
+<link href="_content/Cropper.Blazor/cropper.min.css" rel="stylesheet" />


### PR DESCRIPTION
Fix typo in Link href url

## Target

 There is in a typo in the css link url.
<!--
  Why are you making this change?
  

 -->

#### Open Questions
<!-- OPTIONAL
  - [ ] Use the GitHub checklists to spark discussion on issues that may arise from your approach. Please tick the box and explain your answer.
-->

## Checklist
<!--
  It serves as a gentle reminder for common tasks. Confirm it's done and check everything that applies.
-->
- [ ] Tests cover new or modified code
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the site documentation
- [ ] I have made corresponding changes to the README, NuGet README file
- [ ] My changes generate no new warnings
- [ ] New dependencies added or updated
- [ ] Includes breaking changes
- [ ] Version bumped

## Visuals
<!-- OPTIONAL
  Show results both before and after this change. When the output changes, it can be a screenshot of a trace, metric, or log illustrating the change.
-->
