### PR TITLE
Add 'ErrorLoadImageContent' parameter for cropper component

### DIFF
--- a/src/Cropper.Blazor/Cropper.Blazor.UnitTests/Components/CropperComponent_Should.cs
+++ b/src/Cropper.Blazor/Cropper.Blazor.UnitTests/Components/CropperComponent_Should.cs
@@ -938,6 +938,56 @@ namespace Cropper.Blazor.UnitTests.Components
         }
 
         [Fact]
+        public void Should_Render_CropperComponent_With_ErrorLoadImageContent_Parameter()
+        {
+            // arrange
+            RenderFragment errorLoadImageContent = builder =>
+            {
+                builder.OpenElement(0, "div");
+                builder.AddAttribute(1, "class", "error-img");
+                builder.CloseElement();
+            };
+            Dictionary<string, object> inputAttributes = new()
+            {
+                { "loading", "lazy" },
+                { "Attribute_TEST", "TEST_VALUE" },
+                { "src", "new_src" }
+            };
+
+            ComponentParameter errorLoadImageContentParameter = ComponentParameter.CreateParameter(
+                nameof(CropperComponent.ErrorLoadImageContent),
+                errorLoadImageContent);
+            ComponentParameter loadingParameter = ComponentParameter.CreateParameter(
+                nameof(CropperComponent.InputAttributes),
+                inputAttributes);
+            ComponentParameter isErrorLoadImage = ComponentParameter.CreateParameter(
+                nameof(CropperComponent.IsErrorLoadImage),
+                true);
+
+            // act
+            IRenderedComponent<CropperComponent> cropperComponent = _testContext
+                .RenderComponent<CropperComponent>(
+                    errorLoadImageContentParameter,
+                    loadingParameter,
+                    isErrorLoadImage);
+
+            // assert
+            IElement expectedElement = cropperComponent.Find("div.error-img");
+            ElementReference? elementReference = cropperComponent.Instance
+                .GetCropperElementReference();
+
+            elementReference.Should().BeNull();
+            expectedElement.ClassName.Should().Be("error-img");
+
+            _mockCropperJsInterop.Verify(c => c.InitCropperAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<ElementReference>(),
+                It.IsAny<Options>(),
+                It.IsAny<DotNetObjectReference<ICropperComponentBase>>(),
+                It.IsAny<CancellationToken>()), Times.Never());
+        }
+
+        [Fact]
         public void Should_Not_Render_CropperComponent_With_IsNotAvaibleInitCropper_Parameter()
         {
             // arrange

--- a/src/Cropper.Blazor/Cropper.Blazor/Components/CropperComponent.razor
+++ b/src/Cropper.Blazor/Cropper.Blazor/Components/CropperComponent.razor
@@ -2,9 +2,16 @@
 
 @if (IsErrorLoadImage == true)
 {
-    <img class="@ErrorLoadImageClass"
-         @attributes="InputAttributes"
-         src="@ErrorLoadImageSrc">
+    @if (ErrorLoadImageContent is null)
+    {
+        <img class="@ErrorLoadImageClass"
+             @attributes="InputAttributes"
+             src="@ErrorLoadImageSrc">
+    }
+    else
+    {
+        @ErrorLoadImageContent
+    }
 }
 else
 {

--- a/src/Cropper.Blazor/Cropper.Blazor/Components/CropperComponent.razor.cs
+++ b/src/Cropper.Blazor/Cropper.Blazor/Components/CropperComponent.razor.cs
@@ -80,6 +80,12 @@ namespace Cropper.Blazor.Components
         public bool IsErrorLoadImage { get; set; }
 
         /// <summary>
+        /// Content is shown instead of the default error image.
+        /// </summary>
+        [Parameter]
+        public RenderFragment? ErrorLoadImageContent { get; set; }
+
+        /// <summary>
         /// Responsible for allowing the initialization of the cropper after a successful image download, the default is always allowed (true).
         /// In addition, it should be used to disable re-initialization (replace image) of cropper after successful image load when set to false.
         /// </summary>


### PR DESCRIPTION
## Target
<!--
  Why are you making this change?
 -->
Add 'ErrorLoadImageContent' parameter for cropper component
#### Open Questions
<!-- OPTIONAL
  - [ ] Use the GitHub checklists to spark discussion on issues that may arise from your approach. Please tick the box and explain your answer.
-->

## Checklist
<!--
  It serves as a gentle reminder for common tasks. Confirm it's done and check everything that applies.
-->
- [x] Tests cover new or modified code
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the site documentation
- [ ] I have made corresponding changes to the README, NuGet README file
- [x] My changes generate no new warnings
- [ ] New dependencies added or updated
- [ ] Includes breaking changes
- [ ] Version bumped

## Visuals
<!-- OPTIONAL
  Show results both before and after this change. When the output changes, it can be a screenshot of a trace, metric, or log illustrating the change.
-->
